### PR TITLE
Adding simple README. fixes #1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+Processing Web Site
+==========
+
+This is the official source code for the [processing.org Web site](http://processing.org), including the examples and the reference.
+
+If you have found an error in the Processing Web site, examples, or the reference, you can file it here under the ["issues" tab](https://github.com/processing/processing-web/issues).
+
+The [processing](https://github.com/processing/processing) repository contains the source code for Processing itself. (Please use that link to file issues regarding the Processing software.)
+
+<!-- Thanks Ben, Casey, and all the contributors for all things Processing! -->


### PR DESCRIPTION
Just a simple README.md based of Ben's work in the main processing repo.

It reads:
# Processing Web Site

This is the official source code for the [processing.org Web site](http://processing.org), including the examples and the reference.

If you have found an error in the Processing Web site, examples, or the reference, you can file it here under the ["issues" tab](https://github.com/processing/processing-web/issues).

The [processing](https://github.com/processing/processing) repository contains the source code for Processing itself. (Please use that link to file issues regarding the Processing software.)

<!-- Thanks Ben, Casey, and all the contributors for all things Processing! -->
