### PR TITLE
Normalizing the xml comment to match all other xml examples. Fixes #6.

### DIFF
--- a/content/api_en/XML_getContent.xml
+++ b/content/api_en/XML_getContent.xml
@@ -12,13 +12,15 @@
 <example>
 <image></image>
 <code><![CDATA[
-// The following short XML file called "sites.xml" is parsed 
-// in the code below. It must be in the project's "data" directory
-// &#60;?xml version="1.0"?&#62;
-// &#60;websites&#62;
-//   &#60;site id="0" url="processing.org"&#62;Processing&#60;/site&#62;
-//   &#60;site id="1" url="mobile.processing.org"&#62;Processing Mobile&#60;/site&#62;
-// &#60;/websites&#62;
+// The following short XML file called "mammals.xml" is parsed
+// in the code below. It must be in the project's "data" folder.
+//
+// &lt;?xml version=&quot;1.0&quot;?&gt;
+// &lt;mammals&gt;
+//   &lt;animal id=&quot;0&quot; species=&quot;Capra hircus&quot;&gt;Goat&lt;/animal&gt;
+//   &lt;animal id=&quot;1&quot; species=&quot;Panthera pardus&quot;&gt;Leopard&lt;/animal&gt;
+//   &lt;animal id=&quot;2&quot; species=&quot;Equus zebra&quot;&gt;Zebra&lt;/animal&gt;
+// &lt;/mammals&gt;
 
 XML xml;
 


### PR DESCRIPTION
I used the same commented xml example that existed in other related doco.

Unfortunately, a small goat was killed to placate the terminology gods (the old example used the term _directory_ instead of _folder_; the former being more correct, the latter more consistent with other doco).
