### PR TITLE
Clarifying behavior of Client#write

### DIFF
--- a/content/api_en/LIB_net/Client_write.xml
+++ b/content/api_en/LIB_net/Client_write.xml
@@ -48,7 +48,7 @@ void draw() {
 </example>
 
 <description><![CDATA[
-Writes data to a server specified when constructing the client.
+Writes data to a server specified when constructing the client, or writes data to the specific client obtained from the Server <b>available()</b> method.
 ]]></description>
 
 


### PR DESCRIPTION
Adding more information to Client#write, to clarify that servers can write to specific clients using the Client instance returned by Server#available().

This is not mentioned anywhere in the documentation, resulting in questions like this:
http://forum.processing.org/one/topic/how-do-i-send-data-to-only-one-client-using-the-network-library.html
