### PR TITLE
BaseWriter.getAnchorFromName: use the last parenthetical instead of the first

### DIFF
--- a/java_generate/ReferenceGenerator/src/writers/BaseWriter.java
+++ b/java_generate/ReferenceGenerator/src/writers/BaseWriter.java
@@ -159,8 +159,8 @@ public class BaseWriter {
 		}
 		// change "(some thing)" to something
 		if( name.contains("(") && name.contains(")") ){
-			int start = name.indexOf("(") + 1;
-			int end = name.indexOf(")");
+			int start = name.lastIndexOf("(") + 1;
+			int end = name.lastIndexOf(")");
 			name = name.substring(start, end);
 			name = name.replace(" ", "");
 		}


### PR DESCRIPTION
Otherwise, links to "() (parentheses)" point to `.html` instead of `parentheses.html`.

This can be seen in the current version of the reference here: http://processing.org/reference/curlybraces.html.
