### PR TITLE
Make IndexWriter.Alphabetizer conform to the Comparator requirements

### DIFF
--- a/java_generate/ReferenceGenerator/src/writers/IndexWriter.java
+++ b/java_generate/ReferenceGenerator/src/writers/IndexWriter.java
@@ -30,7 +30,7 @@ public class IndexWriter extends BaseWriter {
 			else if( inside2.matches( "[a-zA-Z0-9 ]+" ) && ! inside1.matches("[a-zA-Z0-9 ]+") )
 			{
 				// if only the first is a symbol
-				return 0;
+				return -1;
 			}
 			
 			// compare whole strings, starting with words


### PR DESCRIPTION
That is, make it return "less" when the first string starts with a symbol, and the second one doesn't. Otherwise `compare(a, b)` may not equal `-compare(b, a)`, and sorting might fail.
