### PR TITLE
Create print.css

### DIFF
--- a/css/print.css
+++ b/css/print.css
@@ -1,0 +1,27 @@
+#header {
+    width: auto !important;
+    background: none !important;
+    height: auto !important;
+}
+#header *, .navBar, #navigation {
+    display: none !important;
+}
+#header:after {
+    content: "Processing 2.0";
+    font-size: 30pt !important;
+    color: #0C2033 !important;
+    line-height: normal;
+}
+
+#container, #container>* {
+    width: auto !important;
+}
+.content {
+    float: none !important;
+}
+.ref-item ~ br {
+    display: none;
+}
+#footer {
+    padding: 10px !important;
+}


### PR DESCRIPTION
This is a print-specific stylesheet, tested on Firefox Nightly 29.0a1 (homepage and reference), IE11 (reference), and Chrome 31.0.1650.63 (reference). It isn't fully tested, but seems OK on what I've done.
It isn't added to any of the pages since I don't know PHP and couldn't see the spot anyway.
For #226.
Note that the page will have no header below IE8, Opera 4, or Safari 4, as there's no `:after` support, but since there wasn't one anyway as it was a non-printing `background-image`, it's not a regression. I recommend that you add one as real HTML text - even if it's normally hidden - as that would solve it, and then obviously alter the CSS file I've attached.
