### PR TITLE
Fix loading jQuery in the offline reference

### DIFF
--- a/java_generate/ReferenceGenerator/src/writers/TemplateWriter.java
+++ b/java_generate/ReferenceGenerator/src/writers/TemplateWriter.java
@@ -65,12 +65,14 @@ public class TemplateWriter extends BaseWriter {
 		ArrayList<String> output = new ArrayList<String>();
 		vars.put("timestamp", getTimestamp());
 		if(isLocal)
-		{ //add local nav
+		{
 			vars.put( "webcontentpath",  getRelativePathToRoot( outputName ) );
+			vars.put("jquery", writePartial("jquery.local.partial.html", vars));
 			vars.put("navigation", writePartial("nav.local.template.html", vars));
 		} else
 		{
 			vars.put( "webcontentpath",  "/" );
+			vars.put("jquery", writePartial("jquery.web.partial.html", vars));
 			vars.put("navigation", writePartial("nav.web.template.html", vars));
 		}
 

--- a/java_generate/templates/class.template.html
+++ b/java_generate/templates/class.template.html
@@ -122,7 +122,7 @@ Updated on <!-- timestamp --><br /><br />
   			</div>
   			
 		</div>
-		<script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+		<!-- jquery -->
 		<script src="<!-- webcontentpath -->javascript/site.js" type="text/javascript"></script>
 	</body>
 

--- a/java_generate/templates/generic.template.html
+++ b/java_generate/templates/generic.template.html
@@ -123,7 +123,7 @@ Updated on <!-- timestamp --><br /><br />
   			</div>
   			
 		</div>
-		<script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+		<!-- jquery -->
 		<script src="<!-- webcontentpath -->javascript/site.js" type="text/javascript"></script>
 	</body>
 </html>

--- a/java_generate/templates/index.alphabetical.template.html
+++ b/java_generate/templates/index.alphabetical.template.html
@@ -17,10 +17,6 @@
 	
 		<script src="<!-- webcontentpath -->javascript/modernizr-2.6.2.touch.js" type="text/javascript"></script>
 		<link href="<!-- webcontentpath -->css/style.css" rel="stylesheet" type="text/css" />
-		
-		<script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
-		<script>window.jQuery || document.write('<script src="<!-- webcontentpath -->javascript/jquery-1.9.1.min.js"><\/script>')</script>
-		<script src="<!-- webcontentpath -->javascript/site.js" type="text/javascript"></script>
 	</head>
 	<body id="A-Z" onload="" >
 		
@@ -88,8 +84,7 @@
   			</div>
   			
 		</div>
-		<script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
-		<script>window.jQuery || document.write('<script src="<!-- webcontentpath -->javascript/jquery-1.9.1.min.js"><\/script>')</script>
+		<!-- jquery -->
 		<script src="<!-- webcontentpath -->javascript/site.js" type="text/javascript"></script>
 	</body>
 </html>

--- a/java_generate/templates/index.template.html
+++ b/java_generate/templates/index.template.html
@@ -266,8 +266,7 @@
   			</div>
   			
 		</div>
-		<script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
-		<script>window.jQuery || document.write('<script src="<!-- webcontentpath -->javascript/jquery-1.9.1.min.js"><\/script>')</script>
+		<!-- jquery -->
 		<script src="<!-- webcontentpath -->javascript/site.js" type="text/javascript"></script>
 
 		<script type="text/javascript">

--- a/java_generate/templates/jquery.local.partial.html
+++ b/java_generate/templates/jquery.local.partial.html
@@ -1,0 +1,1 @@
+<script src="<!-- webcontentpath -->javascript/jquery-1.9.1.min.js"></script>

--- a/java_generate/templates/jquery.web.partial.html
+++ b/java_generate/templates/jquery.web.partial.html
@@ -1,0 +1,2 @@
+<script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+<script>window.jQuery || document.write('<script src="<!-- webcontentpath -->javascript/jquery-1.9.1.min.js"><\\/script>');</script>

--- a/java_generate/templates/library.index.template.html
+++ b/java_generate/templates/library.index.template.html
@@ -79,8 +79,7 @@
   			</div>
   			
 		</div>
-		<script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
-		<script>window.jQuery || document.write('<script src="<!-- webcontentpath -->javascript/jquery-1.9.1.min.js"><\/script>')</script>
+		<!-- jquery -->
 		<script src="<!-- webcontentpath -->javascript/site.js" type="text/javascript"></script>
 	</body>
 


### PR DESCRIPTION
Currently, jQuery is being loaded from Google's CDN via a schemaless URI reference `//ajax.googleapis.com/...`. When the reference is viewed offline, that URI reference resolves to `file://ajax.googleapis.com/...`, which causes two problems:

1) jQuery is obviously not loaded (can be checked by seeing whether the navbar remains pinned to the top of the page when scrolling). This is mitigated by the fallbacks on some pages that attempt to load the local copy of jQuery if the Google copy didn't load, although some pages lack the fallbacks.

2) More importantly, when viewed on Windows, this causes long browser freezes, as Windows tries to look up the script in a shared folder on ajax.googleapis.com, which only fails after a long timeout.

This commit fixes both problems by making the offline reference only refer to the local copy of jQuery.

An easier way to fix this would be to _always_ use the local copy, but I assume you don't want that.
