### PR TITLE
Fix Movie.duration() code example

### DIFF
--- a/content/api_en/LIB_video/Movie_duration.xml
+++ b/content/api_en/LIB_video/Movie_duration.xml
@@ -19,9 +19,9 @@ void setup() {
   size(200, 200);
   frameRate(30);
   myMovie = new Movie(this, "totoro.mov");
+  myMovie.play();
   // Prints the duration of the movie
   println(myMovie.duration());
-  myMovie.play();
 }
 
 void draw() {


### PR DESCRIPTION
Fix for issue #376.
