### PR TITLE
Fix #339 Update link to Processing 2.0 forum

### DIFF
--- a/content/api_en/libraries/index.html
+++ b/content/api_en/libraries/index.html
@@ -58,7 +58,7 @@
 	Contributed libraries are developed, documented, and maintained by members of the Processing 
 	community. For feedback and support, please post to the <a href="http://forum.processing.org">
 	Forum</a>. For development discussions post to the 
-	<a href="http://forum.processing.org/library-and-tool-development">Libraries and Tool Development</a> 
+	<a href="http://forum.processing.org/two/categories/create-announce-libraries">Create & Announce Libraries</a> 
 	topic. Instructions for creating your own library are on the <a href="https://github.com/processing/processing/wiki">
 	Processing GitHub</a> site.<br />
 </p>


### PR DESCRIPTION
Fix #339 Updated link (and title) on libraries page to Processing 2.0 forum
