### PR TITLE
Update to non-deprecated method

### DIFF
--- a/content/api_en/mouseWheel.xml
+++ b/content/api_en/mouseWheel.xml
@@ -18,7 +18,7 @@ void setup() {
 void draw() {} 
 
 void mouseWheel(MouseEvent event) {
-  float e = event.getAmount();
+  float e = event.getCount();
   println(e);
 }
 


### PR DESCRIPTION
Issue #224 reports that the mouseWheel() reference example uses a [deprecated method](http://processing.org/reference/javadoc/core/processing/event/MouseEvent.html#getAmount%28%29). This issue is fixed by this pull request.
